### PR TITLE
Add support for multi-batch Produce request and response

### DIFF
--- a/src/rdbuf.h
+++ b/src/rdbuf.h
@@ -308,6 +308,8 @@ size_t rd_slice_reader(rd_slice_t *slice, const void **p);
 size_t rd_slice_peeker(const rd_slice_t *slice, const void **p);
 
 size_t rd_slice_read(rd_slice_t *slice, void *dst, size_t size);
+size_t rd_slice_read_into_buf(rd_slice_t *slice, rd_buf_t *rbuf, size_t size);
+
 size_t
 rd_slice_peek(const rd_slice_t *slice, size_t offset, void *dst, size_t size);
 

--- a/src/rdkafka_broker.c
+++ b/src/rdkafka_broker.c
@@ -771,7 +771,12 @@ void rd_kafka_broker_conn_closed(rd_kafka_broker_t *rkb,
 rd_bool_t buf_contains_toppar(rd_kafka_buf_t *rkbuf, rd_kafka_toppar_t *rktp) {
 
         if (rd_list_cnt(&rkbuf->rkbuf_u.Produce.batch_list) > 0) {
-                /* this is multi-batch request, loop through all batches */
+                /* this is multi-batch request, loop through all batches.
+                   The size of this list is bounded by number of topic+partition
+                   this broker thread manages. In reality it's likely to be
+                   significantly smaller than that, given not all toppars has
+                   ready batch (linger, batch-size constraints) in each iteration
+                   of processing */
                 rd_kafka_msgbatch_t *msgbatch;
                 int i;
                 RD_LIST_FOREACH(msgbatch, &rkbuf->rkbuf_u.Produce.batch_list, i) {

--- a/src/rdkafka_buf.c
+++ b/src/rdkafka_buf.c
@@ -57,6 +57,13 @@ void rd_kafka_buf_destroy_final(rd_kafka_buf_t *rkbuf) {
 
         case RD_KAFKAP_Produce:
                 rd_kafka_msgbatch_destroy(&rkbuf->rkbuf_batch);
+                int i;
+                rd_kafka_msgbatch_t *msgbatch;
+                RD_LIST_FOREACH(msgbatch, &rkbuf->rkbuf_u.Produce.batch_list, i) {
+                        rd_kafka_msgbatch_destroy(msgbatch);
+                        rd_free(msgbatch);
+                }
+                rd_list_destroy(&rkbuf->rkbuf_u.Produce.batch_list);
                 break;
         }
 

--- a/src/rdkafka_buf.h
+++ b/src/rdkafka_buf.h
@@ -399,6 +399,11 @@ struct rd_kafka_buf_s { /* rd_kafka_buf_t */
                 } Metadata;
                 struct {
                         rd_kafka_msgbatch_t batch; /**< MessageSet/batch */
+                        rd_list_t batch_list;      /* MessageSet/batch list*/
+                        size_t batch_start_pos;    /* Pos where Record batch
+                                                    * starts in the buf */
+                        size_t batch_end_pos;      /* Pos after Record batch +
+                                                    * Partition tags in the buf */
                 } Produce;
                 struct {
                         rd_bool_t commit; /**< true = txn commit,

--- a/src/rdkafka_msg.h
+++ b/src/rdkafka_msg.h
@@ -84,6 +84,7 @@ typedef struct rd_kafka_Produce_result {
             *record_errors; /**< Errors for records that caused the batch to be
                                dropped */
         int32_t record_errors_cnt; /**< record_errors count */
+        rd_kafka_resp_err_t errorcode; /**< error code from the response */
 } rd_kafka_Produce_result_t;
 
 typedef struct rd_kafka_msg_s {

--- a/src/rdkafka_msgset_writer.c
+++ b/src/rdkafka_msgset_writer.c
@@ -460,6 +460,9 @@ rd_kafka_msgset_writer_write_Produce_header(rd_kafka_msgset_writer_t *msetw) {
         /* MessageSetSize: Will be finalized later*/
         msetw->msetw_of_MessageSetSize = rd_kafka_buf_write_arraycnt_pos(rkbuf);
 
+        // For multi-batch requests, here where we start copying the batch
+        rkbuf->rkbuf_u.Produce.batch_start_pos = msetw->msetw_of_MessageSetSize;
+
         if (msetw->msetw_MsgVersion == 2) {
                 /* MessageSet v2 header */
                 rd_kafka_msgset_writer_write_MessageSet_v2_header(msetw);
@@ -1399,6 +1402,10 @@ rd_kafka_msgset_writer_finalize(rd_kafka_msgset_writer_t *msetw,
 
         /* Partition tags */
         rd_kafka_buf_write_tags_empty(rkbuf);
+
+        /* Save the position of end of batch + partition tags for multi-batch req */
+        rkbuf->rkbuf_u.Produce.batch_end_pos = rd_buf_write_pos(&rkbuf->rkbuf_buf);
+
         /* Topics tags */
         rd_kafka_buf_write_tags_empty(rkbuf);
 

--- a/src/rdkafka_request.h
+++ b/src/rdkafka_request.h
@@ -447,7 +447,13 @@ void rd_kafka_SaslAuthenticateRequest(rd_kafka_broker_t *rkb,
 int rd_kafka_ProduceRequest(rd_kafka_broker_t *rkb,
                             rd_kafka_toppar_t *rktp,
                             const rd_kafka_pid_t pid,
-                            uint64_t epoch_base_msgid);
+                            uint64_t epoch_base_msgid,
+                            rd_bool_t skip_sending,
+                            rd_list_t *batch_bufq);
+
+int rd_kafka_MultiBatchProduceRequest(rd_kafka_broker_t *rkb,
+                            const rd_kafka_pid_t pid,
+                            rd_list_t *batch_bufq);
 
 rd_kafka_resp_err_t
 rd_kafka_CreateTopicsRequest(rd_kafka_broker_t *rkb,

--- a/tests/0012-produce_consume.c
+++ b/tests/0012-produce_consume.c
@@ -101,6 +101,8 @@ static void produce_messages(uint64_t testid,
         if (!rkt)
                 TEST_FAIL("Failed to create topic: %s\n", rd_strerror(errno));
 
+        test_create_partitions(rk, topic, partition_cnt);
+
         /* Create messages. */
         prod_msg_remains = msgcnt;
         rkmessages       = calloc(sizeof(*rkmessages), msgcnt / partition_cnt);
@@ -492,7 +494,7 @@ static void consume_messages_with_queues(uint64_t testid,
  */
 static void test_produce_consume(void) {
         int msgcnt        = test_quick ? 100 : 1000;
-        int partition_cnt = 2;
+        int partition_cnt = 10;
         int i;
         uint64_t testid;
         int msg_base = 0;


### PR DESCRIPTION
### Description 

This PR adds the support for "multi RecordBatch" Produce request and response. The principle of the PR is: 
* it relies on existing librdkafka code to handle per RecordBatch level request encoding and response handling. In details, logics such as batching/compression/error-handling are entirely executed by existing code.
* it only adds code to encode/decode the "multi-batch" aspect, e.g. to encode nested structure of topic/partition information (topic name, count, partition index, etc)
* as much as possible, it avoided the duplication of encoding logic, and relying instead on copying of already encoded buffer (by existing code). The downside of this approach is that it introduces an extra copy of post-compressed data, which is a trade-off we made in order to support this feature with minimum code change.

The PR supports the current Produce request version in librdkafka v10. There is an attached pcap file to show the multi-batch request and response. 

### Testing
The PR is tested by running the entire [test suite](https://github.com/confluentinc/librdkafka/tree/master/tests) against a Kafka cluster of version 3.7.1. In particular, 3 runs (see below) are performed and have the same results.
- tests on master, without patch
- with patch, but with multi-batch disabled
- with patch, but with multi-batch enabled

In addition, a few tests are spot-tested by running with valgrind to ensure no memory leak. 
As the PR does not introduce any thread/locking related change, no tests in this aspect is done.

### Remaining work
* adding proper feature flag for enable/disabling multi-batch feature
* topics with certain different settings (such as # of acks) should not be packed into a single ProduceRequest, currently this logic of missing
* adding a test. Existing tests already exercises the new code path and produce multi-batch request/response, but adding a complete new test could be nice



[librdkafka-test-0012.pcap.gz](https://github.com/user-attachments/files/16425125/librdkafka-test-0012.pcap.gz)






