### PR TITLE
Datadog fixes

### DIFF
--- a/src/rdkafka_partition.c
+++ b/src/rdkafka_partition.c
@@ -1359,7 +1359,7 @@ static void rd_kafka_toppar_handle_Offset(rd_kafka_t *rk,
 
         rd_kafka_toppar_lock(rktp);
         /* Drop reply from previous partition leader */
-        if (err != RD_KAFKA_RESP_ERR__DESTROY && rktp->rktp_broker != rkb)
+        if (err != RD_KAFKA_RESP_ERR__DESTROY && rktp->rktp_leader != rkb)
                 err = RD_KAFKA_RESP_ERR__OUTDATED;
         rd_kafka_toppar_unlock(rktp);
 
@@ -1549,7 +1549,7 @@ void rd_kafka_toppar_offset_request(rd_kafka_toppar_t *rktp,
         rd_kafka_assert(NULL,
                         thrd_is_current(rktp->rktp_rkt->rkt_rk->rk_thread));
 
-        rkb = rktp->rktp_broker;
+        rkb = rktp->rktp_leader;
 
         if (!backoff_ms && (!rkb || rkb->rkb_source == RD_KAFKA_INTERNAL))
                 backoff_ms = 500;

--- a/src/rdkafka_topic.c
+++ b/src/rdkafka_topic.c
@@ -1830,27 +1830,6 @@ int rd_kafka_topic_info_cmp(const void *_a, const void *_b) {
         if ((r = RD_CMP(a->partition_cnt, b->partition_cnt)))
                 return r;
 
-        if (a->partitions_internal == NULL && b->partitions_internal == NULL)
-                return 0;
-
-        if (a->partitions_internal == NULL || b->partitions_internal == NULL)
-                return (a->partitions_internal == NULL) ? 1 : -1;
-
-        /* We're certain partitions_internal exist for a/b and have the same
-         * count. */
-        for (i = 0; i < a->partition_cnt; i++) {
-                size_t k;
-                if ((r = RD_CMP(a->partitions_internal[i].racks_cnt,
-                                b->partitions_internal[i].racks_cnt)))
-                        return r;
-
-                for (k = 0; k < a->partitions_internal[i].racks_cnt; k++) {
-                        if ((r = rd_strcmp(a->partitions_internal[i].racks[k],
-                                           b->partitions_internal[i].racks[k])))
-                                return r;
-                }
-        }
-
         return 0;
 }
 

--- a/tests/0104-fetch_from_follower_mock.c
+++ b/tests/0104-fetch_from_follower_mock.c
@@ -29,6 +29,7 @@
 
 #include "test.h"
 
+#include "../src/rdkafka_protocol.h"
 
 /**
  * @name Fetch from follower tests using the mock broker.
@@ -110,6 +111,11 @@ static void do_test_offset_reset(const char *auto_offset_reset) {
                 test_consumer_poll_no_msgs(auto_offset_reset, c, 0, 5000);
         else
                 test_consumer_poll(auto_offset_reset, c, 0, 1, 0, msgcnt, NULL);
+
+        /* send another batch of messages to ensure the consumer isn't stuck */
+        test_produce_msgs_easy_v(topic, 0, 0, 0, msgcnt, 1000,
+                                 "bootstrap.servers", bootstraps, NULL);
+        test_consumer_poll("ASSIGN", c, 0, 1, 0, msgcnt, NULL);
 
         test_consumer_close(c);
 


### PR DESCRIPTION
These contain fixes that were here: https://github.com/DataDog/devtools/tree/master/deb/dd-librdkafka-2.4 .

Once this lands, I'll add a `dd-librdkafka-2.5` there.