### PR TITLE
Prevent broker delegation from getting stuck

### DIFF
--- a/src/rdkafka_broker.c
+++ b/src/rdkafka_broker.c
@@ -3345,6 +3345,7 @@ rd_kafka_broker_op_serve(rd_kafka_broker_t *rkb, rd_kafka_op_t *rko) {
                 rkb->rkb_toppar_cnt++;
                 rd_kafka_broker_unlock(rkb);
                 rktp->rktp_broker = rkb;
+                rktp->rktp_broker_id = rkb->rkb_nodeid;
                 rd_assert(!rktp->rktp_msgq_wakeup_q);
                 rktp->rktp_msgq_wakeup_q = rd_kafka_q_keep(rkb->rkb_ops);
                 rd_kafka_broker_keep(rkb);
@@ -3446,6 +3447,7 @@ rd_kafka_broker_op_serve(rd_kafka_broker_t *rkb, rd_kafka_op_t *rko) {
                         rktp->rktp_msgq_wakeup_q = NULL;
                 }
                 rktp->rktp_broker = NULL;
+                rktp->rktp_broker_id = -1;
 
                 rd_assert(rktp->rktp_flags & RD_KAFKA_TOPPAR_F_ON_RKB);
                 rktp->rktp_flags &= ~RD_KAFKA_TOPPAR_F_ON_RKB;

--- a/src/rdkafka_topic.c
+++ b/src/rdkafka_topic.c
@@ -603,9 +603,6 @@ int rd_kafka_toppar_broker_update(rd_kafka_toppar_t *rktp,
                                   int32_t broker_id,
                                   rd_kafka_broker_t *rkb,
                                   const char *reason) {
-
-        rktp->rktp_broker_id = broker_id;
-
         if (!rkb) {
                 int had_broker = rktp->rktp_broker ? 1 : 0;
                 rd_kafka_toppar_broker_delegate(rktp, NULL);
@@ -613,7 +610,7 @@ int rd_kafka_toppar_broker_update(rd_kafka_toppar_t *rktp,
         }
 
         if (rktp->rktp_broker) {
-                if (rktp->rktp_broker == rkb) {
+                if (rktp->rktp_broker == rkb && !rktp->rktp_next_broker) {
                         /* No change in broker */
                         return 0;
                 }


### PR DESCRIPTION
Two related changes here:
1. `rktp_broker_id` can become inconsistent with `rktp_broker` when a broker update changes the broker id but `rd_kafka_toppar_broker_delegate` opts to ignore the migration. `rtkp_broker_id` is only ever compared against `rtkp_leader_id` when deciding to revert to the leader, so we just delay this until the partition is _actually_ migrated like `rtkp_broker`.
2. If we quickly migrate from A -> B then B -> A, the check on the second migration will incorrectly ignore the broker migration if the first op hasn't been processed yet. Instead we just always enqueue another migration if there is a migration already in progress.

The easiest way to reproduce this issue is to do a large scale reassignment on a cluster - I was able to reproduce a partition getting stuck consistently with a 12 broker cluster, 512 partitions, and 8 consumers. I wasn't able to reproduce the race condition in a unit test.