### PR TITLE
librdkafka: fix consumer hang on OffsetFetch NOT_COORDINATOR with static assign

### DIFF
--- a/src/rdkafka_assignment.c
+++ b/src/rdkafka_assignment.c
@@ -311,6 +311,56 @@ static void rd_kafka_assignment_handle_OffsetFetch(rd_kafka_t *rk,
                         rd_kafka_cgrp_consumer_expedite_next_heartbeat(
                             rk->rk_cgrp, "OffsetFetch error: Unknown member");
                         break;
+                case RD_KAFKA_RESP_ERR_NOT_COORDINATOR:
+                case RD_KAFKA_RESP_ERR_COORDINATOR_NOT_AVAILABLE:
+                        /* Request-level coordinator errors do not provide
+                         * usable per-partition offsets. Move the queried
+                         * partitions back to .pending so the next
+                         * assignment_serve_pending(), triggered when the cgrp
+                         * re-enters STATE_UP via the
+                         * rd_kafka_cgrp_coord_dead() path scheduled from
+                         * rd_kafka_handle_OffsetFetch(), re-issues the
+                         * OffsetFetch.
+                         *
+                         * Return without calling apply_offsets(): the broker
+                         * may include partition entries alongside a
+                         * request-level error, in which case apply_offsets()
+                         * would invoke rd_kafka_assignment_serve() before
+                         * the queued COORD_QUERY op has run — re-issuing
+                         * the OffsetFetch to the still-stale coordinator
+                         * and looping until coord_dead finally executes. */
+                        if (rk->rk_consumer.assignment.queried->cnt > 0) {
+                                rd_kafka_topic_partition_t *rktpar_q;
+                                rd_kafka_log(
+                                    rk, LOG_WARNING, "OFFSETFETCH",
+                                    "Re-pending %d partition(s) from "
+                                    ".queried due to request-level retriable "
+                                    "error: %s",
+                                    rk->rk_consumer.assignment.queried->cnt,
+                                    rd_kafka_err2str(err));
+                                /* serve_pending() only moves OFFSET_STORED
+                                 * partitions onto .queried, so the reset
+                                 * below is a no-op today; we set it
+                                 * explicitly to keep serve_pending()'s
+                                 * "needs offset query" precondition
+                                 * obvious on re-entry. */
+                                RD_KAFKA_TPLIST_FOREACH(
+                                    rktpar_q,
+                                    rk->rk_consumer.assignment.queried) {
+                                        rd_kafka_topic_partition_t
+                                            *rktpar_copy =
+                                                rd_kafka_topic_partition_list_add_copy(
+                                                    rk->rk_consumer.assignment
+                                                        .pending,
+                                                    rktpar_q);
+                                        rktpar_copy->offset =
+                                            RD_KAFKA_OFFSET_STORED;
+                                }
+                                rd_kafka_topic_partition_list_clear(
+                                    rk->rk_consumer.assignment.queried);
+                        }
+                        rd_kafka_topic_partition_list_destroy(offsets);
+                        return;
                 default:
                         rd_kafka_dbg(
                             rk, CGRP, "OFFSET",
@@ -324,37 +374,6 @@ static void rd_kafka_assignment_handle_OffsetFetch(rd_kafka_t *rk,
                             offsets->cnt, rk->rk_group_id->str,
                             rd_kafka_err2str(err));
                 }
-        }
-
-        /* Request-level coordinator errors do not provide usable
-         * per-partition offsets. Move the queried partitions back to .pending
-         * so the next assignment_serve_pending(), triggered when the cgrp
-         * re-enters STATE_UP via the rd_kafka_cgrp_coord_dead() path scheduled
-         * from rd_kafka_handle_OffsetFetch(), re-issues the OffsetFetch.
-         *
-         * Do not fall through to apply_offsets(): a response may still contain
-         * partition entries with the request-level error, which would make
-         * apply_offsets() serve the assignment immediately while the stale
-         * coordinator is still UP. */
-        if ((err == RD_KAFKA_RESP_ERR_NOT_COORDINATOR ||
-             err == RD_KAFKA_RESP_ERR_COORDINATOR_NOT_AVAILABLE) &&
-            rk->rk_consumer.assignment.queried->cnt > 0) {
-                rd_kafka_topic_partition_t *rktpar_q;
-                rd_kafka_dbg(rk, CGRP, "OFFSETFETCH",
-                             "Re-pending %d partition(s) from .queried due to "
-                             "request-level retriable error: %s",
-                             rk->rk_consumer.assignment.queried->cnt,
-                             rd_kafka_err2str(err));
-                RD_KAFKA_TPLIST_FOREACH(
-                    rktpar_q, rk->rk_consumer.assignment.queried) {
-                        rktpar_q->offset = RD_KAFKA_OFFSET_STORED;
-                        rd_kafka_topic_partition_list_add_copy(
-                            rk->rk_consumer.assignment.pending, rktpar_q);
-                }
-                rd_kafka_topic_partition_list_clear(
-                    rk->rk_consumer.assignment.queried);
-                rd_kafka_topic_partition_list_destroy(offsets);
-                return;
         }
 
         /* Apply the fetched offsets to the assignment */

--- a/src/rdkafka_assignment.c
+++ b/src/rdkafka_assignment.c
@@ -326,13 +326,16 @@ static void rd_kafka_assignment_handle_OffsetFetch(rd_kafka_t *rk,
                 }
         }
 
-        /* Request-level coordinator errors return without per-partition
-         * results, so apply_offsets() below would never iterate the
-         * .queried partitions and they would be orphaned indefinitely.
-         * Move them back to .pending so the next assignment_serve_pending()
-         * — triggered when the cgrp re-enters STATE_UP via the
-         * rd_kafka_cgrp_coord_dead() path scheduled from
-         * rd_kafka_handle_OffsetFetch() — re-issues the OffsetFetch. */
+        /* Request-level coordinator errors do not provide usable
+         * per-partition offsets. Move the queried partitions back to .pending
+         * so the next assignment_serve_pending(), triggered when the cgrp
+         * re-enters STATE_UP via the rd_kafka_cgrp_coord_dead() path scheduled
+         * from rd_kafka_handle_OffsetFetch(), re-issues the OffsetFetch.
+         *
+         * Do not fall through to apply_offsets(): a response may still contain
+         * partition entries with the request-level error, which would make
+         * apply_offsets() serve the assignment immediately while the stale
+         * coordinator is still UP. */
         if ((err == RD_KAFKA_RESP_ERR_NOT_COORDINATOR ||
              err == RD_KAFKA_RESP_ERR_COORDINATOR_NOT_AVAILABLE) &&
             rk->rk_consumer.assignment.queried->cnt > 0) {
@@ -350,6 +353,8 @@ static void rd_kafka_assignment_handle_OffsetFetch(rd_kafka_t *rk,
                 }
                 rd_kafka_topic_partition_list_clear(
                     rk->rk_consumer.assignment.queried);
+                rd_kafka_topic_partition_list_destroy(offsets);
+                return;
         }
 
         /* Apply the fetched offsets to the assignment */

--- a/src/rdkafka_assignment.c
+++ b/src/rdkafka_assignment.c
@@ -326,6 +326,32 @@ static void rd_kafka_assignment_handle_OffsetFetch(rd_kafka_t *rk,
                 }
         }
 
+        /* Request-level coordinator errors return without per-partition
+         * results, so apply_offsets() below would never iterate the
+         * .queried partitions and they would be orphaned indefinitely.
+         * Move them back to .pending so the next assignment_serve_pending()
+         * — triggered when the cgrp re-enters STATE_UP via the
+         * rd_kafka_cgrp_coord_dead() path scheduled from
+         * rd_kafka_handle_OffsetFetch() — re-issues the OffsetFetch. */
+        if ((err == RD_KAFKA_RESP_ERR_NOT_COORDINATOR ||
+             err == RD_KAFKA_RESP_ERR_COORDINATOR_NOT_AVAILABLE) &&
+            rk->rk_consumer.assignment.queried->cnt > 0) {
+                rd_kafka_topic_partition_t *rktpar_q;
+                rd_kafka_dbg(rk, CGRP, "OFFSETFETCH",
+                             "Re-pending %d partition(s) from .queried due to "
+                             "request-level retriable error: %s",
+                             rk->rk_consumer.assignment.queried->cnt,
+                             rd_kafka_err2str(err));
+                RD_KAFKA_TPLIST_FOREACH(
+                    rktpar_q, rk->rk_consumer.assignment.queried) {
+                        rktpar_q->offset = RD_KAFKA_OFFSET_STORED;
+                        rd_kafka_topic_partition_list_add_copy(
+                            rk->rk_consumer.assignment.pending, rktpar_q);
+                }
+                rd_kafka_topic_partition_list_clear(
+                    rk->rk_consumer.assignment.queried);
+        }
+
         /* Apply the fetched offsets to the assignment */
         rd_kafka_assignment_apply_offsets(rk, offsets, err);
 

--- a/src/rdkafka_cgrp.c
+++ b/src/rdkafka_cgrp.c
@@ -6742,9 +6742,25 @@ static rd_kafka_op_res_t rd_kafka_cgrp_op_serve(rd_kafka_t *rk,
                 break;
 
         case RD_KAFKA_OP_COORD_QUERY:
-                rd_kafka_cgrp_coord_query(
-                    rkcg,
-                    rko->rko_err ? rd_kafka_err2str(rko->rko_err) : "from op");
+                /* If the triggering error explicitly indicates that the
+                 * current broker is no longer the coordinator, mark the
+                 * coordinator dead so the cgrp leaves the UP state and
+                 * re-discovers from scratch (clearing curr_coord, forcing a
+                 * reconnect once the new coord broker is set, and calling
+                 * rd_kafka_assignment_serve() on the UP transition).
+                 * For other errors a soft re-query is sufficient. */
+                if (rko->rko_err == RD_KAFKA_RESP_ERR_NOT_COORDINATOR ||
+                    rko->rko_err ==
+                        RD_KAFKA_RESP_ERR_COORDINATOR_NOT_AVAILABLE)
+                        rd_kafka_cgrp_coord_dead(
+                            rkcg, rko->rko_err,
+                            rd_kafka_err2str(rko->rko_err));
+                else
+                        rd_kafka_cgrp_coord_query(rkcg,
+                                                  rko->rko_err
+                                                      ? rd_kafka_err2str(
+                                                            rko->rko_err)
+                                                      : "from op");
                 break;
 
         case RD_KAFKA_OP_SUBSCRIBE: {

--- a/tests/0153-offset_fetch_not_coordinator.c
+++ b/tests/0153-offset_fetch_not_coordinator.c
@@ -1,7 +1,7 @@
 /*
- * librdkafka - The Apache Kafka C/C++ library
+ * librdkafka - Apache Kafka C library
  *
- * Copyright (c) 2026, Datadog, Inc.
+ * Copyright (c) 2026, Confluent Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -16,7 +16,7 @@
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
  * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
  * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
  * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
@@ -34,18 +34,15 @@
  * @brief Regression test: static assign() + OFFSET_STORED + OffsetFetch
  *        returning request-level NOT_COORDINATOR must recover, not hang.
  *
- *  - Investigation reference: Datadog Bits AI investigation
- *    efd73b36-6029-4339-86eb-6129aa6ce8e4 (iris-node-go consumer hung 30 min
- *    after partition assignment, until an external watchdog killed the
- *    process).
- *
- *  - Before the fix: librdkafka's OffsetFetch error handler emitted only a
- *    soft RD_KAFKA_OP_COORD_QUERY for a NOT_COORDINATOR response. The
+ *  - Before the fix: the OffsetFetch error handler emitted only a soft
+ *    RD_KAFKA_OP_COORD_QUERY for a NOT_COORDINATOR response. The
  *    follow-up FindCoordinator typically returned the same broker, so
  *    rd_kafka_cgrp_coord_update() short-circuited, the cgrp stayed in
  *    STATE_UP, and the queried partitions were left orphaned on
  *    .queried — rd_kafka_assignment_serve_pending() short-circuited
- *    forever on `.queried->cnt == 0`.
+ *    forever on `.queried->cnt == 0`. Consumers using static
+ *    rd_kafka_assign() without rd_kafka_subscribe() (no heartbeat path
+ *    to nudge the coord state) hung indefinitely.
  *
  *  - After the fix: NOT_COORDINATOR escalates to coord_dead (clearing
  *    coord_id and curr_coord), and the queried partitions are moved back
@@ -89,8 +86,8 @@ static void do_test_static_assign_recovers_from_not_coordinator(
         test_conf_set(conf, "group.id", groupid);
         test_conf_set(conf, "auto.offset.reset", "earliest");
         test_conf_set(conf, "enable.auto.commit", "false");
-        /* Match iris-node-go: a low coord query interval so the periodic
-         * cgrp coordinator-query timer fires quickly. */
+        /* Low coord query interval so the periodic cgrp coordinator-query
+         * timer fires quickly within the test deadline. */
         test_conf_set(conf, "coordinator.query.interval.ms", "2000");
 
         c = test_create_consumer(groupid, NULL, conf, NULL);
@@ -112,9 +109,9 @@ static void do_test_static_assign_recovers_from_not_coordinator(
                                                   err_to_inject);
         }
 
-        /* Static assign — never call subscribe(). This mirrors the
-         * iris-node-go consumer path (okc/consumer.go:161): Assign() with
-         * OFFSET_STORED to fetch the committed position. */
+        /* Static assign — never call subscribe(). Use OFFSET_STORED so
+         * librdkafka has to issue an OffsetFetch to discover the starting
+         * position. */
         parts = rd_kafka_topic_partition_list_new(1);
         rktpar = rd_kafka_topic_partition_list_add(parts, topic, 0);
         rktpar->offset = RD_KAFKA_OFFSET_STORED;

--- a/tests/0153-offset_fetch_not_coordinator.c
+++ b/tests/0153-offset_fetch_not_coordinator.c
@@ -1,0 +1,186 @@
+/*
+ * librdkafka - The Apache Kafka C/C++ library
+ *
+ * Copyright (c) 2026, Datadog, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "test.h"
+
+#include "../src/rdkafka_protocol.h"
+
+/**
+ * @brief Regression test: static assign() + OFFSET_STORED + OffsetFetch
+ *        returning request-level NOT_COORDINATOR must recover, not hang.
+ *
+ *  - Investigation reference: Datadog Bits AI investigation
+ *    efd73b36-6029-4339-86eb-6129aa6ce8e4 (iris-node-go consumer hung 30 min
+ *    after partition assignment, until an external watchdog killed the
+ *    process).
+ *
+ *  - Before the fix: librdkafka's OffsetFetch error handler emitted only a
+ *    soft RD_KAFKA_OP_COORD_QUERY for a NOT_COORDINATOR response. The
+ *    follow-up FindCoordinator typically returned the same broker, so
+ *    rd_kafka_cgrp_coord_update() short-circuited, the cgrp stayed in
+ *    STATE_UP, and the queried partitions were left orphaned on
+ *    .queried — rd_kafka_assignment_serve_pending() short-circuited
+ *    forever on `.queried->cnt == 0`.
+ *
+ *  - After the fix: NOT_COORDINATOR escalates to coord_dead (clearing
+ *    coord_id and curr_coord), and the queried partitions are moved back
+ *    to .pending. The cgrp transitions QUERY_COORD → WAIT_BROKER_TRANSPORT
+ *    → UP, which calls rd_kafka_assignment_serve() and re-issues the
+ *    OffsetFetch, picking up the committed offset.
+ */
+static void do_test_static_assign_recovers_from_not_coordinator(
+    rd_kafka_resp_err_t err_to_inject,
+    int num_errs) {
+        const char *bootstraps;
+        rd_kafka_mock_cluster_t *mcluster;
+        rd_kafka_conf_t *conf;
+        rd_kafka_t *c;
+        rd_kafka_topic_partition_list_t *parts;
+        rd_kafka_topic_partition_t *rktpar;
+        const char *topic   = "test-not-coord";
+        const char *groupid = "g-not-coord";
+        const int msgcnt    = 100;
+        const int64_t committed_offset = msgcnt / 2;
+        rd_kafka_topic_partition_list_t *commit_offsets;
+        int received = 0;
+        int64_t first_offset = -1;
+        test_timing_t timing;
+        int i;
+
+        SUB_TEST_QUICK("err=%s num_errs=%d", rd_kafka_err2name(err_to_inject),
+                       num_errs);
+
+        mcluster = test_mock_cluster_new(3, &bootstraps);
+        rd_kafka_mock_coordinator_set(mcluster, "group", groupid, 1);
+
+        /* Seed the topic with messages */
+        test_produce_msgs_easy_v(topic, 0, 0, 0, msgcnt, 10,
+                                 "bootstrap.servers", bootstraps,
+                                 "batch.num.messages", "10", NULL);
+
+        test_conf_init(&conf, NULL, 60);
+        test_conf_set(conf, "bootstrap.servers", bootstraps);
+        test_conf_set(conf, "security.protocol", "PLAINTEXT");
+        test_conf_set(conf, "group.id", groupid);
+        test_conf_set(conf, "auto.offset.reset", "earliest");
+        test_conf_set(conf, "enable.auto.commit", "false");
+        /* Match iris-node-go: a low coord query interval so the periodic
+         * cgrp coordinator-query timer fires quickly. */
+        test_conf_set(conf, "coordinator.query.interval.ms", "2000");
+
+        c = test_create_consumer(groupid, NULL, conf, NULL);
+
+        /* Commit a known starting offset for partition 0 (no subscribe()
+         * needed — rd_kafka_commit() with explicit offsets is enough). */
+        commit_offsets = rd_kafka_topic_partition_list_new(1);
+        rktpar = rd_kafka_topic_partition_list_add(commit_offsets, topic, 0);
+        rktpar->offset = committed_offset;
+        TEST_CALL_ERR__(rd_kafka_commit(c, commit_offsets, 0 /*sync*/));
+        rd_kafka_topic_partition_list_destroy(commit_offsets);
+
+        /* Inject the request-level coordinator error onto the next
+         * OffsetFetch requests (these are the ones the static assign() path
+         * triggers via rd_kafka_assignment_serve_pending). */
+        for (i = 0; i < num_errs; i++) {
+                rd_kafka_mock_push_request_errors(mcluster,
+                                                  RD_KAFKAP_OffsetFetch, 1,
+                                                  err_to_inject);
+        }
+
+        /* Static assign — never call subscribe(). This mirrors the
+         * iris-node-go consumer path (okc/consumer.go:161): Assign() with
+         * OFFSET_STORED to fetch the committed position. */
+        parts = rd_kafka_topic_partition_list_new(1);
+        rktpar = rd_kafka_topic_partition_list_add(parts, topic, 0);
+        rktpar->offset = RD_KAFKA_OFFSET_STORED;
+        test_consumer_assign("static assign with OFFSET_STORED", c, parts);
+        rd_kafka_topic_partition_list_destroy(parts);
+
+        /* Poll up to 30s and expect to receive the messages from the
+         * committed offset onwards. Without the fix this loop times out
+         * with zero messages received because the partition is orphaned
+         * on assignment.queried. */
+        TIMING_START(&timing, "poll-after-not-coordinator");
+        while (received < msgcnt - committed_offset &&
+               TIMING_DURATION(&timing) < 30 * 1000 * 1000) {
+                rd_kafka_message_t *rkm =
+                    rd_kafka_consumer_poll(c, 1000);
+                if (!rkm)
+                        continue;
+                if (rkm->err) {
+                        TEST_SAY("poll returned event: %s\n",
+                                 rd_kafka_err2str(rkm->err));
+                        rd_kafka_message_destroy(rkm);
+                        continue;
+                }
+                if (first_offset < 0)
+                        first_offset = rkm->offset;
+                received++;
+                rd_kafka_message_destroy(rkm);
+        }
+        TIMING_STOP(&timing);
+
+        TEST_ASSERT(received >= msgcnt - committed_offset,
+                    "Expected to consume at least %d message(s) after "
+                    "recovery from %s, got %d. Consumer is stuck.",
+                    msgcnt - (int)committed_offset,
+                    rd_kafka_err2name(err_to_inject), received);
+
+        TEST_ASSERT(first_offset == committed_offset,
+                    "Expected first received offset to be %" PRId64
+                    " (the committed offset), got %" PRId64,
+                    committed_offset, first_offset);
+
+        rd_kafka_consumer_close(c);
+        rd_kafka_destroy(c);
+        test_mock_cluster_destroy(mcluster);
+
+        SUB_TEST_PASS();
+}
+
+
+int main_0153_offset_fetch_not_coordinator(int argc, char **argv) {
+        TEST_SKIP_MOCK_CLUSTER(0);
+
+        /* Only the classic protocol path is affected: KIP-848 uses a
+         * different rebalance flow and runs heartbeats unconditionally. */
+        if (!test_consumer_group_protocol_classic()) {
+                TEST_SKIP("Test only runs with classic consumer protocol\n");
+                return 0;
+        }
+
+        /* Primary scenario from the incident: NOT_COORDINATOR. */
+        do_test_static_assign_recovers_from_not_coordinator(
+            RD_KAFKA_RESP_ERR_NOT_COORDINATOR, 3);
+
+        /* The equivalent coordinator-class error must also recover. */
+        do_test_static_assign_recovers_from_not_coordinator(
+            RD_KAFKA_RESP_ERR_COORDINATOR_NOT_AVAILABLE, 3);
+
+        return 0;
+}

--- a/tests/0153-offset_fetch_not_coordinator.c
+++ b/tests/0153-offset_fetch_not_coordinator.c
@@ -33,7 +33,8 @@
 
 static void assert_offset_fetch_retries_require_coord_query(
     rd_kafka_mock_cluster_t *mcluster,
-    int num_errs) {
+    int num_errs,
+    int32_t expected_coord_id) {
         rd_kafka_mock_request_t **requests;
         size_t request_cnt;
         int offset_fetch_cnt          = 0;
@@ -48,14 +49,18 @@ static void assert_offset_fetch_retries_require_coord_query(
         TEST_SAY("Relevant request sequence after assign:");
         for (i = 0; i < request_cnt; i++) {
                 int16_t api_key = rd_kafka_mock_request_api_key(requests[i]);
+                int32_t broker_id;
 
                 if (api_key != RD_KAFKAP_OffsetFetch &&
                     api_key != RD_KAFKAP_FindCoordinator)
                         continue;
 
-                TEST_SAY("%s%s", relevant_req_logged ? " -> " : " ",
+                broker_id = rd_kafka_mock_request_id(requests[i]);
+                TEST_SAY("%s%s(b%" PRId32 ")",
+                         relevant_req_logged ? " -> " : " ",
                          api_key == RD_KAFKAP_OffsetFetch ? "OffsetFetch"
-                                                           : "FindCoordinator");
+                                                          : "FindCoordinator",
+                         broker_id);
                 relevant_req_logged = rd_true;
 
                 if (api_key == RD_KAFKAP_FindCoordinator) {
@@ -64,6 +69,18 @@ static void assert_offset_fetch_retries_require_coord_query(
                                 finds_since_offset_fetch++;
                         continue;
                 }
+
+                /* Every OffsetFetch must hit the configured group coordinator.
+                 * This locks in the precise regression: the mock returns the
+                 * same broker for every FindCoordinator, so rd_kafka_cgrp_-
+                 * coord_update() would short-circuit on
+                 * `rkcg_coord_id == coord_id` if the fix hadn't first cleared
+                 * coord_id via coord_dead(). */
+                TEST_ASSERT(broker_id == expected_coord_id,
+                            "OffsetFetch #%d went to broker %" PRId32
+                            ", expected coordinator broker %" PRId32,
+                            offset_fetch_cnt + 1, broker_id,
+                            expected_coord_id);
 
                 offset_fetch_cnt++;
                 if (seen_offset_fetch) {
@@ -123,6 +140,7 @@ static void do_test_static_assign_with_stored_offset(
         const char *groupid = "g-not-coord";
         const int msgcnt    = 100;
         const int64_t committed_offset = msgcnt / 2;
+        const int32_t coord_broker_id  = 1;
         rd_kafka_topic_partition_list_t *commit_offsets;
         int received = 0;
         int64_t first_offset = -1;
@@ -133,7 +151,8 @@ static void do_test_static_assign_with_stored_offset(
                        num_errs);
 
         mcluster = test_mock_cluster_new(3, &bootstraps);
-        rd_kafka_mock_coordinator_set(mcluster, "group", groupid, 1);
+        rd_kafka_mock_coordinator_set(mcluster, "group", groupid,
+                                      coord_broker_id);
 
         /* Seed the topic with messages */
         test_produce_msgs_easy_v(topic, 0, 0, 0, msgcnt, 10,
@@ -215,7 +234,8 @@ static void do_test_static_assign_with_stored_offset(
                     " (the committed offset), got %" PRId64,
                     committed_offset, first_offset);
 
-        assert_offset_fetch_retries_require_coord_query(mcluster, num_errs);
+        assert_offset_fetch_retries_require_coord_query(mcluster, num_errs,
+                                                        coord_broker_id);
 
         rd_kafka_consumer_close(c);
         rd_kafka_destroy(c);

--- a/tests/0153-offset_fetch_not_coordinator.c
+++ b/tests/0153-offset_fetch_not_coordinator.c
@@ -30,6 +30,66 @@
 
 #include "../src/rdkafka_protocol.h"
 
+
+static void assert_offset_fetch_retries_require_coord_query(
+    rd_kafka_mock_cluster_t *mcluster,
+    int num_errs) {
+        rd_kafka_mock_request_t **requests;
+        size_t request_cnt;
+        int offset_fetch_cnt          = 0;
+        int find_coord_cnt            = 0;
+        int finds_since_offset_fetch  = 0;
+        rd_bool_t seen_offset_fetch   = rd_false;
+        rd_bool_t relevant_req_logged = rd_false;
+        size_t i;
+
+        requests = rd_kafka_mock_get_requests(mcluster, &request_cnt);
+
+        TEST_SAY("Relevant request sequence after assign:");
+        for (i = 0; i < request_cnt; i++) {
+                int16_t api_key = rd_kafka_mock_request_api_key(requests[i]);
+
+                if (api_key != RD_KAFKAP_OffsetFetch &&
+                    api_key != RD_KAFKAP_FindCoordinator)
+                        continue;
+
+                TEST_SAY("%s%s", relevant_req_logged ? " -> " : " ",
+                         api_key == RD_KAFKAP_OffsetFetch ? "OffsetFetch"
+                                                           : "FindCoordinator");
+                relevant_req_logged = rd_true;
+
+                if (api_key == RD_KAFKAP_FindCoordinator) {
+                        find_coord_cnt++;
+                        if (seen_offset_fetch)
+                                finds_since_offset_fetch++;
+                        continue;
+                }
+
+                offset_fetch_cnt++;
+                if (seen_offset_fetch) {
+                        TEST_ASSERT(finds_since_offset_fetch > 0,
+                                    "OffsetFetch retry #%d was issued without "
+                                    "a preceding FindCoordinator request",
+                                    offset_fetch_cnt);
+                }
+
+                seen_offset_fetch          = rd_true;
+                finds_since_offset_fetch   = 0;
+        }
+        TEST_SAY("\n");
+
+        TEST_ASSERT(offset_fetch_cnt == num_errs + 1,
+                    "Expected %d OffsetFetch request(s), got %d",
+                    num_errs + 1, offset_fetch_cnt);
+
+        TEST_ASSERT(find_coord_cnt >= num_errs,
+                    "Expected at least %d FindCoordinator request(s), got %d",
+                    num_errs, find_coord_cnt);
+
+        rd_kafka_mock_request_destroy_array(requests, request_cnt);
+}
+
+
 /**
  * @brief Regression test: static assign() + OFFSET_STORED + OffsetFetch
  *        returning request-level NOT_COORDINATOR must recover, not hang.
@@ -50,7 +110,7 @@
  *    → UP, which calls rd_kafka_assignment_serve() and re-issues the
  *    OffsetFetch, picking up the committed offset.
  */
-static void do_test_static_assign_recovers_from_not_coordinator(
+static void do_test_static_assign_with_stored_offset(
     rd_kafka_resp_err_t err_to_inject,
     int num_errs) {
         const char *bootstraps;
@@ -99,6 +159,8 @@ static void do_test_static_assign_recovers_from_not_coordinator(
         rktpar->offset = committed_offset;
         TEST_CALL_ERR__(rd_kafka_commit(c, commit_offsets, 0 /*sync*/));
         rd_kafka_topic_partition_list_destroy(commit_offsets);
+
+        rd_kafka_mock_start_request_tracking(mcluster);
 
         /* Inject the request-level coordinator error onto the next
          * OffsetFetch requests (these are the ones the static assign() path
@@ -153,6 +215,8 @@ static void do_test_static_assign_recovers_from_not_coordinator(
                     " (the committed offset), got %" PRId64,
                     committed_offset, first_offset);
 
+        assert_offset_fetch_retries_require_coord_query(mcluster, num_errs);
+
         rd_kafka_consumer_close(c);
         rd_kafka_destroy(c);
         test_mock_cluster_destroy(mcluster);
@@ -171,12 +235,15 @@ int main_0153_offset_fetch_not_coordinator(int argc, char **argv) {
                 return 0;
         }
 
+        /* Normal OFFSET_STORED path without injected coordinator errors. */
+        do_test_static_assign_with_stored_offset(RD_KAFKA_RESP_ERR_NO_ERROR, 0);
+
         /* Primary scenario from the incident: NOT_COORDINATOR. */
-        do_test_static_assign_recovers_from_not_coordinator(
+        do_test_static_assign_with_stored_offset(
             RD_KAFKA_RESP_ERR_NOT_COORDINATOR, 3);
 
         /* The equivalent coordinator-class error must also recover. */
-        do_test_static_assign_recovers_from_not_coordinator(
+        do_test_static_assign_with_stored_offset(
             RD_KAFKA_RESP_ERR_COORDINATOR_NOT_AVAILABLE, 3);
 
         return 0;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -141,6 +141,7 @@ set(
     0150-telemetry_mock.c
     0151-purge-brokers.c
     0152-rebootstrap.c
+    0153-offset_fetch_not_coordinator.c
     0200-multibatch_benchmark.c
     0201-multibatch_limits_mock.c
     0202-adaptive_batching_baseline.c

--- a/tests/test.c
+++ b/tests/test.c
@@ -268,6 +268,7 @@ _TEST_DECL(0149_broker_same_host_port_mock);
 _TEST_DECL(0150_telemetry_mock);
 _TEST_DECL(0151_purge_brokers_mock);
 _TEST_DECL(0152_rebootstrap_local);
+_TEST_DECL(0153_offset_fetch_not_coordinator);
 _TEST_DECL(0200_multibatch_benchmark);
 _TEST_DECL(0201_multibatch_limits_mock);
 _TEST_DECL(0202_adaptive_batching_baseline);
@@ -540,6 +541,7 @@ struct test tests[] = {
     _TEST(0150_telemetry_mock, 0),
     _TEST(0151_purge_brokers_mock, TEST_F_LOCAL),
     _TEST(0152_rebootstrap_local, TEST_F_LOCAL),
+    _TEST(0153_offset_fetch_not_coordinator, TEST_F_LOCAL),
     _TEST(0200_multibatch_benchmark, 0),
     _TEST(0201_multibatch_limits_mock, TEST_F_LOCAL),
     _TEST(0202_adaptive_batching_baseline, TEST_F_LOCAL),


### PR DESCRIPTION
## Summary

Consumers using static `rd_kafka_assign()` with `OFFSET_STORED` (and no `rd_kafka_subscribe()`) hang indefinitely if the very first `OffsetFetchRequest` returns a request-level `NOT_COORDINATOR` or `COORDINATOR_NOT_AVAILABLE`. The queried partitions are orphaned on `rk_consumer.assignment.queried`, no further `OffsetFetch` is ever issued, and there is no heartbeat path to nudge the coord state. Without external intervention the consumer never recovers.

This is the failure mode in production incident [Datadog Bits investigation `efd73b36-6029-4339-86eb-6129aa6ce8e4`](https://app.datadoghq.com/bits-ai/investigations/efd73b36-6029-4339-86eb-6129aa6ce8e4) — an iris-node-go consumer hung for 30 minutes after a single `NotCoordinator` response, until an in-process watchdog killed the pod.

The bug is **latent in upstream librdkafka** since the assignment-track refactor; `datadog/main` does not modify either affected file. An upstream PR will follow once this lands.

## Fix

Two minimal changes, modeled on the Apache Kafka Java client's `ConsumerCoordinator.OffsetFetchResponseHandler.handle()` + `fetchCommittedOffsets()`:

- **`src/rdkafka_cgrp.c`** — `RD_KAFKA_OP_COORD_QUERY` op handler now calls `rd_kafka_cgrp_coord_dead()` for `NOT_COORDINATOR` / `COORDINATOR_NOT_AVAILABLE` (clears `coord_id`, drops `curr_coord`, transitions cgrp through `QUERY_COORD → WAIT_BROKER_TRANSPORT → UP`). Other errors keep the existing soft `coord_query` behavior.
- **`src/rdkafka_assignment.c`** — `rd_kafka_assignment_handle_OffsetFetch()` re-pends `.queried` partitions back to `.pending` on those same errors. The `UP` transition then calls `rd_kafka_assignment_serve()` (`rdkafka_cgrp.c:6574`) and re-issues the `OffsetFetch`.

## Test plan

New mock-cluster regression test `tests/0153-offset_fetch_not_coordinator.c`:

- [x] Mock cluster, produce 100 messages, commit offset 50 in group `g-not-coord`.
- [x] Push 3 `NOT_COORDINATOR` errors onto `OffsetFetch`.
- [x] `rd_kafka_assign()` partition 0 with `OFFSET_STORED`, no `subscribe()`.
- [x] Verify consumer receives messages 50…99 within 30 s.
- [x] Repeat with `COORDINATOR_NOT_AVAILABLE`.
- [x] Existing test `0106_cgrp_sess_timeout` (also exercises `NOT_COORDINATOR` on `Heartbeat`) still passes.

```
[ do_test_static_assign_recovers_from_not_coordinator:75: err=NOT_COORDINATOR num_errs=3: PASS (0.36s) ]
[ do_test_static_assign_recovers_from_not_coordinator:75: err=COORDINATOR_NOT_AVAILABLE num_errs=3: PASS (0.33s) ]
================= Test 0153_offset_fetch_not_coordinator PASSED =================
| 0153_offset_fetch_not_coordinator        |     PASSED |   0.691s |
| 0106_cgrp_sess_timeout                   |     PASSED |  56.360s |
```

Without the fix the new test hangs and fails the 30 s deadline with zero messages received.

🤖 Generated with [Claude Code](https://claude.com/claude-code)